### PR TITLE
Add a concatenated compiled shortstack dataframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ These instructions will get you a copy of the project up and running on your loc
 ### Create a Conda environment
 This Snakemake pipeline make use of the [conda package manager](https://docs.conda.io/en/latest/) to install softwares and dependencies.
 1. First, make sure you have conda installed on your system. Use [Miniconda3](https://docs.conda.io/en/latest/miniconda.html) and follow the [installation instructions](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).  
-2. Using `conda`, create a virtual environment called `snakemake` to install Snakemake (version 5.4.3 or higher) by executing the following code in a Shell window: `conda create --name snakemake -c bioconda snakemake=5.4.3 pandas=0.24.2`. This will install `snakemake version 5.4.3` and `pandas version 0.24.2` in a new environment called __snakemake__.
+2. Using `conda`, create a virtual environment called `snakemake` to install Snakemake (version 5.4.3 or higher) by executing the following code in a Shell window: `conda env create -f envs/snakemake.yaml`. This will install `snakemake version 5.4.3` and `pandas version 0.25.0` in a new environment called __snakemake__.
 3. Activate this environment using: `source activate snakemake`
 4. You can now run the pipeline (see below) since snakemake will use conda to install softwares and packages for each rule.  
 

--- a/Snakefile
+++ b/Snakefile
@@ -8,6 +8,8 @@ from helpers import converts_list_of_sequence_dictionary_to_fasta
 from helpers import add_blast_header_to_file
 from helpers import add_sample_name_and_hairpin_seq_to_shortstack
 from helpers import concatenate_shortstacks_and_assign_unique_cluster_ids
+from helpers import extract_mature_micrornas_from_concatenated_shortstack_file
+from helpers import extract_hairpins_from_concatenated_shortstack_file
 
 ##### set minimum snakemake version #####
 min_version("5.4.3")
@@ -37,8 +39,8 @@ SHORTSTACK_PARAMS = " ".join(config["shortstack"].values())
 SHORTSTACK = expand(RES_DIR + "shortstack/{sample}/Results.with_sample_name_and_hairpins.tsv",sample = SAMPLES)
 SHORTSTACK_CONCAT = RES_DIR + "concatenated_shortstacks.tsv"
 
-MIRNAS = expand(RES_DIR + "fasta/{sample}.mature_mirnas.fasta",sample = SAMPLES)
-HAIRPINS = expand(RES_DIR + "fasta/{sample}.hairpin.fasta",sample = SAMPLES)
+MIRNAS = [expand(RES_DIR + "fasta/{sample}.mature_mirnas.fasta",sample = SAMPLES), RES_DIR + "mature_mirnas.fasta"]
+HAIRPINS = [expand(RES_DIR + "fasta/{sample}.hairpin.fasta",sample = SAMPLES), RES_DIR + "hairpins.fasta"]
 
 BLAST = expand(RES_DIR + "blast/{sample}.{type}_mirbase.header.txt",sample = SAMPLES, type = ["mature","hairpin"])
 
@@ -61,6 +63,18 @@ rule all:
 #############################################
 # Produce a concatenated Shortstack dataframe
 #############################################
+
+rule extract_fasta_files_for_hairpins_and_mature_miRNAs_from_concatenated_shortstack: 
+    input:
+        RES_DIR + "concatenated_shortstacks.tsv" 
+    output:
+        hairpins = RES_DIR + "hairpins.fasta",
+        mature = RES_DIR + "mature_mirnas.fasta"
+    message: "extract hairpins and mature miRNAs from {input}"
+    run:
+        extract_hairpins_from_concatenated_shortstack_file(input[0], output[0])
+        extract_mature_micrornas_from_concatenated_shortstack_file(input[0], output[1])
+
 
 rule concatenate_shorstacks_and_assign_unique_cluster_ids:
     input:
@@ -189,9 +203,8 @@ rule extract_mature_mirna_fasta_file:
         df_mirnas = df[df["MIRNA"] == "Y"]
         mirnas_dict = df_mirnas["MajorRNA"].to_dict()
         # convert to fasta format
-        with open(output[0],"w") as fileout:
-            for name, sequence in mirnas_dict.items():
-                fileout.write(">" + name + "\n" + sequence + "\n")
+
+
 
 ######################
 ## Shortstack analysis

--- a/envs/snakemake.yaml
+++ b/envs/snakemake.yaml
@@ -1,0 +1,8 @@
+name: snakemake
+channels:
+  - bioconda
+  - conda-forge  
+dependencies:
+  - snakemake-minimal = 5.4.3 
+  - biopython = 1.74
+  - pandas = 0.25.0

--- a/helpers.py
+++ b/helpers.py
@@ -183,4 +183,34 @@ def concatenate_shortstacks_and_assign_unique_cluster_ids(list_of_shortstack_fil
     df["cluster_unique_id"] = ["cluster_" + str(i+1).zfill(10) for i in range(0,df.shape[0],1)]  
     df.to_csv(outfile, sep="\t", index=False, header=True)
 
+def extract_hairpins_from_concatenated_shortstack_file(concatenated_shortstack_file, outfile):
+    """
+    Extract the hairpin sequences from the concatenated shortstack dataframe.
+    The hairpin identifier is a unique cluster identifier.
+    """
+    concatenated_shortstack_df = pd.read_csv(concatenated_shortstack_file, sep="\t")
+    df_with_only_mirnas = concatenated_shortstack_df.query(" MIRNA == 'Y' ") # only true MIRNAs have a hairpin sequence
+
+    cluster_ids = df_with_only_mirnas["cluster_unique_id"]
+    hairpin_seqs = df_with_only_mirnas["hairpin"]
+
+    with open(outfile, "w") as fileout:
+        for cluster_id, hairpin_seq in zip(cluster_ids, hairpin_seqs):
+                fileout.write(">" + cluster_id + "\n" + hairpin_seq + "\n")
+
+
+def extract_mature_micrornas_from_concatenated_shortstack_file(concatenated_shortstack_file, outfile):
+    """
+    Extract the mature miRNA sequences from the concatenated shortstack dataframe.
+    The mature miRNA identifier is a unique cluster identifier.
+    """
+    concatenated_shortstack_df = pd.read_csv(concatenated_shortstack_file, sep="\t")
+    df_with_only_mirnas = concatenated_shortstack_df.query(" MIRNA == 'Y' ") # only true MIRNAs are kept
+
+    cluster_ids = df_with_only_mirnas["cluster_unique_id"]
+    major_rna_seqs = df_with_only_mirnas["MajorRNA"]
+
+    with open(outfile, "w") as fileout:
+        for cluster_id, major_rna_seq in zip(cluster_ids, major_rna_seqs):
+                fileout.write(">" + cluster_id + "\n" + major_rna_seq + "\n")
 

--- a/helpers.py
+++ b/helpers.py
@@ -173,7 +173,7 @@ def add_sample_name_and_hairpin_seq_to_shortstack(path_to_shortstack_results, sa
     df_with_name_and_hairpin = add_hairpin_sequence_to_shortstack_results(df_with_name, hairpin_fasta_file)
 
     # write to file
-    df_with_name_and_hairpin.to_csv(outfile, index=False, header=True, na_rep = "NaN")
+    df_with_name_and_hairpin.to_csv(outfile, sep="\t", index=False, header=True, na_rep = "NaN")
 
 
 def concatenate_shortstacks_and_assign_unique_cluster_ids(list_of_shortstack_files,

--- a/helpers.py
+++ b/helpers.py
@@ -108,3 +108,19 @@ def add_blast_header_to_file(blast_file_without_header,blast_file_with_header):
     df = pd.read_csv(blast_file_without_header,sep="\t",header=None)
     df.columns = blast_header
     df.to_csv(blast_file_with_header,sep="\t",header=True,index=False)
+
+
+
+def add_sample_name_to_shortstack_results(
+    path_to_shortstack_results,
+    sample_name,
+    outfile):
+    """
+    Takes a "Results.txt" dataframe as produced by Shorstack.
+    Add the sample name as a new column (sample name is repeated N times (number of rows))
+    Returns a pandas dataframe as specified by outfile
+    """
+    df = pd.read_csv(path_to_shortstack_results,sep="\t")
+    df["sample"] = sample_name
+    df.to_csv(outfile, sep="\t", header=True, index=False)
+

--- a/helpers.py
+++ b/helpers.py
@@ -174,3 +174,13 @@ def add_sample_name_and_hairpin_seq_to_shortstack(path_to_shortstack_results, sa
 
     # write to file
     df_with_name_and_hairpin.to_csv(outfile, index=False, header=True, na_rep = "NaN")
+
+
+def concatenate_shortstacks_and_assign_unique_cluster_ids(list_of_shortstack_files,
+                                                         outfile = "shortstack_concatenated.tsv"):
+    list_of_shortstack_dfs = [pd.read_csv(f,sep="\t") for f in list_of_shortstack_files]
+    df = pd.concat(list_of_shortstack_dfs)
+    df["cluster_unique_id"] = ["cluster_" + str(i+1).zfill(10) for i in range(0,df.shape[0],1)]  
+    df.to_csv(outfile, sep="\t", index=False, header=True)
+
+


### PR DESCRIPTION
This concatenated dataframe contains all discovered sRNA loci in all samples. They can originate from different genomes.   
Sample names are added and the hairpin sequence of discovered MIR genes is also added.   
Finally, a unique non-redundant `cluster_unique_id` is also added to unambiguously refer to each sRNA loci.